### PR TITLE
Change update to draw

### DIFF
--- a/gym_electric_motor/envs/dashboard.py
+++ b/gym_electric_motor/envs/dashboard.py
@@ -78,7 +78,7 @@ class MotorDashboard(object):
         self._figure.show()
         self._figure.canvas.draw()
         self._figure.canvas.flush_events()
-        self._update_figure = self._figure.canvas.update
+        self._update_figure = self._figure.canvas.draw
 
     def reset(self, references):
         """


### PR DESCRIPTION
Update call doesn't work with Python 3.7.2, but draw works. Draw can be
also found from current matplotlib documentation (v3.1.1) whereas update
does not seem to exist for 'FigureCanvasTKAgg'.