### PR TITLE
Ode solver parameterization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 docs/_build/*
 docs/_static/*
 docs/_modules/*
+docs/html/*
+docs/doctrees/*
 !.gitkeep
 
 # IDE 

--- a/docs/parts/environments/scim/scim_envs.rst
+++ b/docs/parts/environments/scim/scim_envs.rst
@@ -1,4 +1,4 @@
-Externally Excited DC Motor Environments
+Squirrel Cage Induction Motor Environments
 ******************************************
 
 

--- a/gym_electric_motor/envs/gym_dcm/extex_dc_motor_env/cont_cc_extex_dc_env.py
+++ b/gym_electric_motor/envs/gym_dcm/extex_dc_motor_env/cont_cc_extex_dc_env.py
@@ -136,7 +136,7 @@ class ContCurrentControlDcExternallyExcitedMotorEnv(ElectricMotorEnvironment):
             ),
             motor=initialize(ps.ElectricMotor, motor, ps.DcExternallyExcitedMotor, dict()),
             load=initialize(ps.MechanicalLoad, load, ps.ConstantSpeedLoad, dict(omega_fixed=100)),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau

--- a/gym_electric_motor/envs/gym_dcm/extex_dc_motor_env/cont_sc_extex_dc_env.py
+++ b/gym_electric_motor/envs/gym_dcm/extex_dc_motor_env/cont_sc_extex_dc_env.py
@@ -134,7 +134,7 @@ class ContSpeedControlDcExternallyExcitedMotorEnv(ElectricMotorEnvironment):
             load=initialize(ps.MechanicalLoad, load, ps.PolynomialStaticLoad, dict(
                 load_parameter=dict(a=0.0, b=0.0, c=0.0, j_load=1e-4)
             )),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau

--- a/gym_electric_motor/envs/gym_dcm/extex_dc_motor_env/cont_tc_extex_dc_env.py
+++ b/gym_electric_motor/envs/gym_dcm/extex_dc_motor_env/cont_tc_extex_dc_env.py
@@ -133,7 +133,7 @@ class ContTorqueControlDcExternallyExcitedMotorEnv(ElectricMotorEnvironment):
             ),
             motor=initialize(ps.ElectricMotor, motor, ps.DcExternallyExcitedMotor, dict()),
             load=initialize(ps.MechanicalLoad, load, ps.ConstantSpeedLoad, dict(omega_fixed=100.0)),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau

--- a/gym_electric_motor/envs/gym_dcm/extex_dc_motor_env/finite_cc_extex_dc_env.py
+++ b/gym_electric_motor/envs/gym_dcm/extex_dc_motor_env/finite_cc_extex_dc_env.py
@@ -133,7 +133,7 @@ class FiniteCurrentControlDcExternallyExcitedMotorEnv(ElectricMotorEnvironment):
             ),
             motor=initialize(ps.ElectricMotor, motor, ps.DcExternallyExcitedMotor, dict()),
             load=initialize(ps.MechanicalLoad, load, ps.ConstantSpeedLoad, dict(omega_fixed=100.0)),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau

--- a/gym_electric_motor/envs/gym_dcm/extex_dc_motor_env/finite_sc_extex_dc_env.py
+++ b/gym_electric_motor/envs/gym_dcm/extex_dc_motor_env/finite_sc_extex_dc_env.py
@@ -135,7 +135,7 @@ class FiniteSpeedControlDcExternallyExcitedMotorEnv(ElectricMotorEnvironment):
             load=initialize(ps.MechanicalLoad, load, ps.PolynomialStaticLoad, dict(
                 load_parameter=dict(a=0.0, b=0.0, c=0.0, j_load=1e-4)
             )),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau

--- a/gym_electric_motor/envs/gym_dcm/extex_dc_motor_env/finite_tc_extex_dc_env.py
+++ b/gym_electric_motor/envs/gym_dcm/extex_dc_motor_env/finite_tc_extex_dc_env.py
@@ -133,7 +133,7 @@ class FiniteTorqueControlDcExternallyExcitedMotorEnv(ElectricMotorEnvironment):
                 dict(subconverters=default_subconverters)),
             motor=initialize(ps.ElectricMotor, motor, ps.DcExternallyExcitedMotor, dict()),
             load=initialize(ps.MechanicalLoad, load, ps.ConstantSpeedLoad, dict(omega_fixed=100.0)),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau

--- a/gym_electric_motor/envs/gym_dcm/permex_dc_motor_env/cont_cc_permex_dc_env.py
+++ b/gym_electric_motor/envs/gym_dcm/permex_dc_motor_env/cont_cc_permex_dc_env.py
@@ -129,7 +129,7 @@ class ContCurrentControlDcPermanentlyExcitedMotorEnv(ElectricMotorEnvironment):
             converter=initialize(ps.PowerElectronicConverter, converter, ps.ContFourQuadrantConverter, dict()),
             motor=initialize(ps.ElectricMotor, motor, ps.DcPermanentlyExcitedMotor, dict()),
             load=initialize(ps.MechanicalLoad, load, ps.ConstantSpeedLoad, dict(omega_fixed=100.0)),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau

--- a/gym_electric_motor/envs/gym_dcm/permex_dc_motor_env/cont_sc_permex_dc_env.py
+++ b/gym_electric_motor/envs/gym_dcm/permex_dc_motor_env/cont_sc_permex_dc_env.py
@@ -129,7 +129,7 @@ class ContSpeedControlDcPermanentlyExcitedMotorEnv(ElectricMotorEnvironment):
             load=initialize(ps.MechanicalLoad, load, ps.PolynomialStaticLoad, dict(
                 load_parameter=dict(a=0.0, b=0.0, c=0.0, j_load=1e-4)
             )),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau

--- a/gym_electric_motor/envs/gym_dcm/permex_dc_motor_env/cont_tc_permex_dc_env.py
+++ b/gym_electric_motor/envs/gym_dcm/permex_dc_motor_env/cont_tc_permex_dc_env.py
@@ -128,7 +128,7 @@ class ContTorqueControlDcPermanentlyExcitedMotorEnv(ElectricMotorEnvironment):
             converter=initialize(ps.PowerElectronicConverter, converter, ps.ContFourQuadrantConverter, dict()),
             motor=initialize(ps.ElectricMotor, motor, ps.DcPermanentlyExcitedMotor, dict()),
             load=initialize(ps.MechanicalLoad, load, ps.ConstantSpeedLoad, dict(omega_fixed=100.0)),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau

--- a/gym_electric_motor/envs/gym_dcm/permex_dc_motor_env/finite_cc_permex_dc_env.py
+++ b/gym_electric_motor/envs/gym_dcm/permex_dc_motor_env/finite_cc_permex_dc_env.py
@@ -129,7 +129,7 @@ class FiniteCurrentControlDcPermanentlyExcitedMotorEnv(ElectricMotorEnvironment)
             converter=initialize(ps.PowerElectronicConverter, converter, ps.FiniteFourQuadrantConverter, dict()),
             motor=initialize(ps.ElectricMotor, motor, ps.DcPermanentlyExcitedMotor, dict()),
             load=initialize(ps.MechanicalLoad, load, ps.ConstantSpeedLoad, dict(omega_fixed=100.0)),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau

--- a/gym_electric_motor/envs/gym_dcm/permex_dc_motor_env/finite_sc_permex_dc_env.py
+++ b/gym_electric_motor/envs/gym_dcm/permex_dc_motor_env/finite_sc_permex_dc_env.py
@@ -132,7 +132,7 @@ class FiniteSpeedControlDcPermanentlyExcitedMotorEnv(ElectricMotorEnvironment):
             load=initialize(ps.MechanicalLoad, load, ps.PolynomialStaticLoad, dict(
                 load_parameter=dict(a=0.0, b=0.0, c=0.0, j_load=1e-3)
             )),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau

--- a/gym_electric_motor/envs/gym_dcm/permex_dc_motor_env/finite_tc_permex_dc_env.py
+++ b/gym_electric_motor/envs/gym_dcm/permex_dc_motor_env/finite_tc_permex_dc_env.py
@@ -129,7 +129,7 @@ class FiniteTorqueControlDcPermanentlyExcitedMotorEnv(ElectricMotorEnvironment):
             converter=initialize(ps.PowerElectronicConverter, converter, ps.FiniteFourQuadrantConverter, dict()),
             motor=initialize(ps.ElectricMotor, motor, ps.DcPermanentlyExcitedMotor, dict()),
             load=initialize(ps.MechanicalLoad, load, ps.ConstantSpeedLoad, dict(omega_fixed=100.0)),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau

--- a/gym_electric_motor/envs/gym_dcm/series_dc_motor_env/cont_cc_series_dc_env.py
+++ b/gym_electric_motor/envs/gym_dcm/series_dc_motor_env/cont_cc_series_dc_env.py
@@ -128,7 +128,7 @@ class ContCurrentControlDcSeriesMotorEnv(ElectricMotorEnvironment):
             converter=initialize(ps.PowerElectronicConverter, converter, ps.ContFourQuadrantConverter, dict()),
             motor=initialize(ps.ElectricMotor, motor, ps.DcSeriesMotor, dict()),
             load=initialize(ps.MechanicalLoad, load, ps.ConstantSpeedLoad, dict(omega_fixed=100)),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau

--- a/gym_electric_motor/envs/gym_dcm/series_dc_motor_env/cont_sc_series_dc_env.py
+++ b/gym_electric_motor/envs/gym_dcm/series_dc_motor_env/cont_sc_series_dc_env.py
@@ -128,9 +128,9 @@ class ContSpeedControlDcSeriesMotorEnv(ElectricMotorEnvironment):
             converter=initialize(ps.PowerElectronicConverter, converter, ps.ContFourQuadrantConverter, dict()),
             motor=initialize(ps.ElectricMotor, motor, ps.DcSeriesMotor, dict()),
             load=initialize(ps.MechanicalLoad, load, ps.PolynomialStaticLoad, dict(
-                load_parameter=dict(a=0.15, b=0.05, c=0.0, j_load=1e-4)
+                load_parameter=dict(a=0.01, b=0.05, c=0.0, j_load=1e-4)
             )),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau

--- a/gym_electric_motor/envs/gym_dcm/series_dc_motor_env/cont_tc_series_dc_env.py
+++ b/gym_electric_motor/envs/gym_dcm/series_dc_motor_env/cont_tc_series_dc_env.py
@@ -128,7 +128,7 @@ class ContTorqueControlDcSeriesMotorEnv(ElectricMotorEnvironment):
             converter=initialize(ps.PowerElectronicConverter, converter, ps.ContFourQuadrantConverter, dict()),
             motor=initialize(ps.ElectricMotor, motor, ps.DcSeriesMotor, dict()),
             load=initialize(ps.MechanicalLoad, load, ps.ConstantSpeedLoad, dict(omega_fixed=100.0)),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau

--- a/gym_electric_motor/envs/gym_dcm/series_dc_motor_env/finite_cc_series_dc_env.py
+++ b/gym_electric_motor/envs/gym_dcm/series_dc_motor_env/finite_cc_series_dc_env.py
@@ -127,7 +127,7 @@ class FiniteCurrentControlDcSeriesMotorEnv(ElectricMotorEnvironment):
             converter=initialize(ps.PowerElectronicConverter, converter, ps.FiniteFourQuadrantConverter, dict()),
             motor=initialize(ps.ElectricMotor, motor, ps.DcSeriesMotor, dict()),
             load=initialize(ps.MechanicalLoad, load, ps.ConstantSpeedLoad, dict(omega_fixed=100.0)),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau

--- a/gym_electric_motor/envs/gym_dcm/series_dc_motor_env/finite_sc_series_dc_env.py
+++ b/gym_electric_motor/envs/gym_dcm/series_dc_motor_env/finite_sc_series_dc_env.py
@@ -129,7 +129,7 @@ class FiniteSpeedControlDcSeriesMotorEnv(ElectricMotorEnvironment):
             load=initialize(ps.MechanicalLoad, load, ps.PolynomialStaticLoad, dict(
                 load_parameter=dict(a=0.15, b=0.05, c=0.0, j_load=1e-4)
             )),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau

--- a/gym_electric_motor/envs/gym_dcm/series_dc_motor_env/finite_tc_series_dc_env.py
+++ b/gym_electric_motor/envs/gym_dcm/series_dc_motor_env/finite_tc_series_dc_env.py
@@ -128,7 +128,7 @@ class FiniteTorqueControlDcSeriesMotorEnv(ElectricMotorEnvironment):
             converter=initialize(ps.PowerElectronicConverter, converter, ps.FiniteFourQuadrantConverter, dict()),
             motor=initialize(ps.ElectricMotor, motor, ps.DcSeriesMotor, dict()),
             load=initialize(ps.MechanicalLoad, load, ps.ConstantSpeedLoad, dict(omega_fixed=100.0)),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau

--- a/gym_electric_motor/envs/gym_dcm/shunt_dc_motor_env/cont_cc_shunt_dc_env.py
+++ b/gym_electric_motor/envs/gym_dcm/shunt_dc_motor_env/cont_cc_shunt_dc_env.py
@@ -129,7 +129,7 @@ class ContCurrentControlDcShuntMotorEnv(ElectricMotorEnvironment):
             converter=initialize(ps.PowerElectronicConverter, converter, ps.ContFourQuadrantConverter, dict()),
             motor=initialize(ps.ElectricMotor, motor, ps.DcShuntMotor, dict()),
             load=initialize(ps.MechanicalLoad, load, ps.ConstantSpeedLoad, dict(omega_fixed=100)),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau

--- a/gym_electric_motor/envs/gym_dcm/shunt_dc_motor_env/cont_sc_shunt_dc_env.py
+++ b/gym_electric_motor/envs/gym_dcm/shunt_dc_motor_env/cont_sc_shunt_dc_env.py
@@ -131,7 +131,7 @@ class ContSpeedControlDcShuntMotorEnv(ElectricMotorEnvironment):
             load=initialize(ps.MechanicalLoad, load, ps.PolynomialStaticLoad, dict(
                 load_parameter=dict(a=0.05, b=0.01, c=0.0, j_load=1e-4)
             )),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau

--- a/gym_electric_motor/envs/gym_dcm/shunt_dc_motor_env/cont_tc_shunt_dc_env.py
+++ b/gym_electric_motor/envs/gym_dcm/shunt_dc_motor_env/cont_tc_shunt_dc_env.py
@@ -129,7 +129,7 @@ class ContTorqueControlDcShuntMotorEnv(ElectricMotorEnvironment):
             converter=initialize(ps.PowerElectronicConverter, converter, ps.ContFourQuadrantConverter, dict()),
             motor=initialize(ps.ElectricMotor, motor, ps.DcShuntMotor, dict()),
             load=initialize(ps.MechanicalLoad, load, ps.ConstantSpeedLoad, dict(omega_fixed=230.0)),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau

--- a/gym_electric_motor/envs/gym_dcm/shunt_dc_motor_env/finite_cc_shunt_dc_env.py
+++ b/gym_electric_motor/envs/gym_dcm/shunt_dc_motor_env/finite_cc_shunt_dc_env.py
@@ -129,7 +129,7 @@ class FiniteCurrentControlDcShuntMotorEnv(ElectricMotorEnvironment):
             converter=initialize(ps.PowerElectronicConverter, converter, ps.FiniteFourQuadrantConverter, dict()),
             motor=initialize(ps.ElectricMotor, motor, ps.DcShuntMotor, dict()),
             load=initialize(ps.MechanicalLoad, load, ps.ConstantSpeedLoad, dict(omega_fixed=100.0)),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau

--- a/gym_electric_motor/envs/gym_dcm/shunt_dc_motor_env/finite_sc_shunt_dc_env.py
+++ b/gym_electric_motor/envs/gym_dcm/shunt_dc_motor_env/finite_sc_shunt_dc_env.py
@@ -131,7 +131,7 @@ class FiniteSpeedControlDcShuntMotorEnv(ElectricMotorEnvironment):
             load=initialize(ps.MechanicalLoad, load, ps.PolynomialStaticLoad, dict(
                 load_parameter=dict(a=0.05, b=0.01, c=0.0, j_load=1e-4)
             )),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau

--- a/gym_electric_motor/envs/gym_dcm/shunt_dc_motor_env/finite_tc_shunt_dc_env.py
+++ b/gym_electric_motor/envs/gym_dcm/shunt_dc_motor_env/finite_tc_shunt_dc_env.py
@@ -128,7 +128,7 @@ class FiniteTorqueControlDcShuntMotorEnv(ElectricMotorEnvironment):
             converter=initialize(ps.PowerElectronicConverter, converter, ps.FiniteFourQuadrantConverter, dict()),
             motor=initialize(ps.ElectricMotor, motor, ps.DcShuntMotor, dict()),
             load=initialize(ps.MechanicalLoad, load, ps.ConstantSpeedLoad, dict(omega_fixed=100.0)),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau

--- a/gym_electric_motor/envs/gym_im/doubly_fed_induction_motor_envs/abccont_cc_dfim_env.py
+++ b/gym_electric_motor/envs/gym_im/doubly_fed_induction_motor_envs/abccont_cc_dfim_env.py
@@ -151,7 +151,7 @@ class AbcContCurrentControlDoublyFedInductionMotorEnv(ElectricMotorEnvironment):
             ),
             motor=initialize(ps.ElectricMotor, motor, ps.DoublyFedInductionMotor, dict()),
             load=initialize(ps.MechanicalLoad, load, ps.ConstantSpeedLoad, dict(omega_fixed=100.0)),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau,

--- a/gym_electric_motor/envs/gym_im/doubly_fed_induction_motor_envs/abccont_sc_dfim_env.py
+++ b/gym_electric_motor/envs/gym_im/doubly_fed_induction_motor_envs/abccont_sc_dfim_env.py
@@ -146,7 +146,7 @@ class AbcContSpeedControlDoublyFedInductionMotorEnv(ElectricMotorEnvironment):
             load=initialize(ps.MechanicalLoad, load, ps.PolynomialStaticLoad, dict(
                 load_parameter=dict(a=0.01, b=0.01, c=0.0)
             )),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau,

--- a/gym_electric_motor/envs/gym_im/doubly_fed_induction_motor_envs/abccont_tc_dfim_env.py
+++ b/gym_electric_motor/envs/gym_im/doubly_fed_induction_motor_envs/abccont_tc_dfim_env.py
@@ -144,7 +144,7 @@ class AbcContTorqueControlDoublyFedInductionMotorEnv(ElectricMotorEnvironment):
             ),
             motor=initialize(ps.ElectricMotor, motor, ps.DoublyFedInductionMotor, dict()),
             load=initialize(ps.MechanicalLoad, load, ps.ConstantSpeedLoad, dict(omega_fixed=100.0)),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau,

--- a/gym_electric_motor/envs/gym_im/doubly_fed_induction_motor_envs/dqcont_cc_dfim_env.py
+++ b/gym_electric_motor/envs/gym_im/doubly_fed_induction_motor_envs/dqcont_cc_dfim_env.py
@@ -148,7 +148,7 @@ class DqContCurrentControlDoublyFedInductionMotorEnv(ElectricMotorEnvironment):
             ),
             motor=initialize(ps.ElectricMotor, motor, ps.DoublyFedInductionMotor, dict()),
             load=initialize(ps.MechanicalLoad, load, ps.ConstantSpeedLoad, dict(omega_fixed=100.0)),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau,

--- a/gym_electric_motor/envs/gym_im/doubly_fed_induction_motor_envs/dqcont_sc_dfim_env.py
+++ b/gym_electric_motor/envs/gym_im/doubly_fed_induction_motor_envs/dqcont_sc_dfim_env.py
@@ -146,7 +146,7 @@ class DqContSpeedControlDoublyFedInductionMotorEnv(ElectricMotorEnvironment):
             load=initialize(ps.MechanicalLoad, load, ps.PolynomialStaticLoad, dict(
                 load_parameter=dict(a=0.01, b=0.01, c=0.0)
             )),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau,

--- a/gym_electric_motor/envs/gym_im/doubly_fed_induction_motor_envs/dqcont_tc_dfim_env.py
+++ b/gym_electric_motor/envs/gym_im/doubly_fed_induction_motor_envs/dqcont_tc_dfim_env.py
@@ -144,7 +144,7 @@ class DqContTorqueControlDoublyFedInductionMotorEnv(ElectricMotorEnvironment):
             ),
             motor=initialize(ps.ElectricMotor, motor, ps.DoublyFedInductionMotor, dict()),
             load=initialize(ps.MechanicalLoad, load, ps.ConstantSpeedLoad, dict(omega_fixed=100.0)),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau,

--- a/gym_electric_motor/envs/gym_im/doubly_fed_induction_motor_envs/finite_cc_dfim_env.py
+++ b/gym_electric_motor/envs/gym_im/doubly_fed_induction_motor_envs/finite_cc_dfim_env.py
@@ -149,7 +149,7 @@ class FiniteCurrentControlDoublyFedInductionMotorEnv(ElectricMotorEnvironment):
             ),
             motor=initialize(ps.ElectricMotor, motor, ps.DoublyFedInductionMotor, dict()),
             load=initialize(ps.MechanicalLoad, load, ps.ConstantSpeedLoad, dict(omega_fixed=100.0)),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau

--- a/gym_electric_motor/envs/gym_im/doubly_fed_induction_motor_envs/finite_sc_dfim_env.py
+++ b/gym_electric_motor/envs/gym_im/doubly_fed_induction_motor_envs/finite_sc_dfim_env.py
@@ -146,7 +146,7 @@ class FiniteSpeedControlDoublyFedInductionMotorEnv(ElectricMotorEnvironment):
             load=initialize(ps.MechanicalLoad, load, ps.PolynomialStaticLoad, dict(
                 load_parameter=dict(a=0.01, b=0.01, c=0.0)
             )),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau

--- a/gym_electric_motor/envs/gym_im/doubly_fed_induction_motor_envs/finite_tc_dfim_env.py
+++ b/gym_electric_motor/envs/gym_im/doubly_fed_induction_motor_envs/finite_tc_dfim_env.py
@@ -144,7 +144,7 @@ class FiniteTorqueControlDoublyFedInductionMotorEnv(ElectricMotorEnvironment):
             ),
             motor=initialize(ps.ElectricMotor, motor, ps.DoublyFedInductionMotor, dict()),
             load=initialize(ps.MechanicalLoad, load, ps.ConstantSpeedLoad, dict(omega_fixed=100.0)),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau

--- a/gym_electric_motor/envs/gym_im/squirrel_cage_induction_motor_envs/abccont_cc_scim_env.py
+++ b/gym_electric_motor/envs/gym_im/squirrel_cage_induction_motor_envs/abccont_cc_scim_env.py
@@ -138,7 +138,7 @@ class AbcContCurrentControlSquirrelCageInductionMotorEnv(ElectricMotorEnvironmen
             converter=initialize(ps.PowerElectronicConverter, converter, ps.ContB6BridgeConverter, dict()),
             motor=initialize(ps.ElectricMotor, motor, ps.SquirrelCageInductionMotor, dict()),
             load=initialize(ps.MechanicalLoad, load, ps.ConstantSpeedLoad, dict(omega_fixed=100.0)),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau,

--- a/gym_electric_motor/envs/gym_im/squirrel_cage_induction_motor_envs/abccont_sc_scim_env.py
+++ b/gym_electric_motor/envs/gym_im/squirrel_cage_induction_motor_envs/abccont_sc_scim_env.py
@@ -136,7 +136,7 @@ class AbcContSpeedControlSquirrelCageInductionMotorEnv(ElectricMotorEnvironment)
             load=initialize(ps.MechanicalLoad, load, ps.PolynomialStaticLoad, dict(
                 load_parameter=dict(a=0.01, b=0.01, c=0.0)
             )),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau,

--- a/gym_electric_motor/envs/gym_im/squirrel_cage_induction_motor_envs/abccont_tc_scim_env.py
+++ b/gym_electric_motor/envs/gym_im/squirrel_cage_induction_motor_envs/abccont_tc_scim_env.py
@@ -133,7 +133,7 @@ class AbcContTorqueControlSquirrelCageInductionMotorEnv(ElectricMotorEnvironment
             converter=initialize(ps.PowerElectronicConverter, converter, ps.ContB6BridgeConverter, dict()),
             motor=initialize(ps.ElectricMotor, motor, ps.SquirrelCageInductionMotor, dict()),
             load=initialize(ps.MechanicalLoad, load, ps.ConstantSpeedLoad, dict(omega_fixed=100.0)),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau,

--- a/gym_electric_motor/envs/gym_im/squirrel_cage_induction_motor_envs/dqcont_cc_scim_env.py
+++ b/gym_electric_motor/envs/gym_im/squirrel_cage_induction_motor_envs/dqcont_cc_scim_env.py
@@ -138,7 +138,7 @@ class DqContCurrentControlSquirrelCageInductionMotorEnv(ElectricMotorEnvironment
             converter=initialize(ps.PowerElectronicConverter, converter, ps.ContB6BridgeConverter, dict()),
             motor=initialize(ps.ElectricMotor, motor, ps.SquirrelCageInductionMotor, dict()),
             load=initialize(ps.MechanicalLoad, load, ps.ConstantSpeedLoad, dict(omega_fixed=100.0)),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau,

--- a/gym_electric_motor/envs/gym_im/squirrel_cage_induction_motor_envs/dqcont_sc_scim_env.py
+++ b/gym_electric_motor/envs/gym_im/squirrel_cage_induction_motor_envs/dqcont_sc_scim_env.py
@@ -136,7 +136,7 @@ class DqContSpeedControlSquirrelCageInductionMotorEnv(ElectricMotorEnvironment):
             load=initialize(ps.MechanicalLoad, load, ps.PolynomialStaticLoad, dict(
                 load_parameter=dict(a=0.01, b=0.01, c=0.0)
             )),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau,

--- a/gym_electric_motor/envs/gym_im/squirrel_cage_induction_motor_envs/dqcont_tc_scim_env.py
+++ b/gym_electric_motor/envs/gym_im/squirrel_cage_induction_motor_envs/dqcont_tc_scim_env.py
@@ -133,7 +133,7 @@ class DqContTorqueControlSquirrelCageInductionMotorEnv(ElectricMotorEnvironment)
             converter=initialize(ps.PowerElectronicConverter, converter, ps.ContB6BridgeConverter, dict()),
             motor=initialize(ps.ElectricMotor, motor, ps.SquirrelCageInductionMotor, dict()),
             load=initialize(ps.MechanicalLoad, load, ps.ConstantSpeedLoad, dict(omega_fixed=100.0)),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau,

--- a/gym_electric_motor/envs/gym_im/squirrel_cage_induction_motor_envs/finite_cc_scim_env.py
+++ b/gym_electric_motor/envs/gym_im/squirrel_cage_induction_motor_envs/finite_cc_scim_env.py
@@ -138,7 +138,7 @@ class FiniteCurrentControlSquirrelCageInductionMotorEnv(ElectricMotorEnvironment
             converter=initialize(ps.PowerElectronicConverter, converter, ps.FiniteB6BridgeConverter, dict()),
             motor=initialize(ps.ElectricMotor, motor, ps.SquirrelCageInductionMotor, dict()),
             load=initialize(ps.MechanicalLoad, load, ps.ConstantSpeedLoad, dict(omega_fixed=100.0)),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau

--- a/gym_electric_motor/envs/gym_im/squirrel_cage_induction_motor_envs/finite_sc_scim_env.py
+++ b/gym_electric_motor/envs/gym_im/squirrel_cage_induction_motor_envs/finite_sc_scim_env.py
@@ -136,7 +136,7 @@ class FiniteSpeedControlSquirrelCageInductionMotorEnv(ElectricMotorEnvironment):
             load=initialize(ps.MechanicalLoad, load, ps.PolynomialStaticLoad, dict(
                 load_parameter=dict(a=0.01, b=0.01, c=0.0)
             )),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau

--- a/gym_electric_motor/envs/gym_im/squirrel_cage_induction_motor_envs/finite_tc_scim_env.py
+++ b/gym_electric_motor/envs/gym_im/squirrel_cage_induction_motor_envs/finite_tc_scim_env.py
@@ -133,7 +133,7 @@ class FiniteTorqueControlSquirrelCageInductionMotorEnv(ElectricMotorEnvironment)
             converter=initialize(ps.PowerElectronicConverter, converter, ps.FiniteB6BridgeConverter, dict()),
             motor=initialize(ps.ElectricMotor, motor, ps.SquirrelCageInductionMotor, dict()),
             load=initialize(ps.MechanicalLoad, load, ps.ConstantSpeedLoad, dict(omega_fixed=100.0)),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau

--- a/gym_electric_motor/envs/gym_pmsm/abccont_cc_pmsm_env.py
+++ b/gym_electric_motor/envs/gym_pmsm/abccont_cc_pmsm_env.py
@@ -133,7 +133,7 @@ class AbcContCurrentControlPermanentMagnetSynchronousMotorEnv(ElectricMotorEnvir
             converter=initialize(ps.PowerElectronicConverter, converter, ps.ContB6BridgeConverter, dict()),
             motor=initialize(ps.ElectricMotor, motor, ps.PermanentMagnetSynchronousMotor, dict()),
             load=initialize(ps.MechanicalLoad, load, ps.ConstantSpeedLoad, dict(omega_fixed=100.0)),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau,

--- a/gym_electric_motor/envs/gym_pmsm/abccont_sc_pmsm_env.py
+++ b/gym_electric_motor/envs/gym_pmsm/abccont_sc_pmsm_env.py
@@ -130,7 +130,7 @@ class AbcContSpeedControlPermanentMagnetSynchronousMotorEnv(ElectricMotorEnviron
             load=initialize(ps.MechanicalLoad, load, ps.PolynomialStaticLoad, dict(
                 load_parameter=dict(a=0.01, b=0.01, c=0.0)
             )),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau,

--- a/gym_electric_motor/envs/gym_pmsm/abccont_tc_pmsm_env.py
+++ b/gym_electric_motor/envs/gym_pmsm/abccont_tc_pmsm_env.py
@@ -128,7 +128,7 @@ class AbcContTorqueControlPermanentMagnetSynchronousMotorEnv(ElectricMotorEnviro
             converter=initialize(ps.PowerElectronicConverter, converter, ps.ContB6BridgeConverter, dict()),
             motor=initialize(ps.ElectricMotor, motor, ps.PermanentMagnetSynchronousMotor, dict()),
             load=initialize(ps.MechanicalLoad, load, ps.ConstantSpeedLoad, dict(omega_fixed=100.0)),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau,

--- a/gym_electric_motor/envs/gym_pmsm/dqcont_cc_pmsm_env.py
+++ b/gym_electric_motor/envs/gym_pmsm/dqcont_cc_pmsm_env.py
@@ -133,7 +133,7 @@ class DqContCurrentControlPermanentMagnetSynchronousMotorEnv(ElectricMotorEnviro
             converter=initialize(ps.PowerElectronicConverter, converter, ps.ContB6BridgeConverter, dict()),
             motor=initialize(ps.ElectricMotor, motor, ps.PermanentMagnetSynchronousMotor, dict()),
             load=initialize(ps.MechanicalLoad, load, ps.ConstantSpeedLoad, dict(omega_fixed=100.0)),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau,

--- a/gym_electric_motor/envs/gym_pmsm/dqcont_sc_pmsm_env.py
+++ b/gym_electric_motor/envs/gym_pmsm/dqcont_sc_pmsm_env.py
@@ -130,7 +130,7 @@ class DqContSpeedControlPermanentMagnetSynchronousMotorEnv(ElectricMotorEnvironm
             load=initialize(ps.MechanicalLoad, load, ps.PolynomialStaticLoad, dict(
                 load_parameter=dict(a=0.01, b=0.01, c=0.0)
             )),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau,

--- a/gym_electric_motor/envs/gym_pmsm/dqcont_tc_pmsm_env.py
+++ b/gym_electric_motor/envs/gym_pmsm/dqcont_tc_pmsm_env.py
@@ -128,7 +128,7 @@ class DqContTorqueControlPermanentMagnetSynchronousMotorEnv(ElectricMotorEnviron
             converter=initialize(ps.PowerElectronicConverter, converter, ps.ContB6BridgeConverter, dict()),
             motor=initialize(ps.ElectricMotor, motor, ps.PermanentMagnetSynchronousMotor, dict()),
             load=initialize(ps.MechanicalLoad, load, ps.ConstantSpeedLoad, dict(omega_fixed=100.0)),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau,

--- a/gym_electric_motor/envs/gym_pmsm/finite_cc_pmsm_env.py
+++ b/gym_electric_motor/envs/gym_pmsm/finite_cc_pmsm_env.py
@@ -133,7 +133,7 @@ class FiniteCurrentControlPermanentMagnetSynchronousMotorEnv(ElectricMotorEnviro
             converter=initialize(ps.PowerElectronicConverter, converter, ps.FiniteB6BridgeConverter, dict()),
             motor=initialize(ps.ElectricMotor, motor, ps.PermanentMagnetSynchronousMotor, dict()),
             load=initialize(ps.MechanicalLoad, load, ps.ConstantSpeedLoad, dict(omega_fixed=100.0)),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau

--- a/gym_electric_motor/envs/gym_pmsm/finite_sc_pmsm_env.py
+++ b/gym_electric_motor/envs/gym_pmsm/finite_sc_pmsm_env.py
@@ -130,7 +130,7 @@ class FiniteSpeedControlPermanentMagnetSynchronousMotorEnv(ElectricMotorEnvironm
             load=initialize(ps.MechanicalLoad, load, ps.PolynomialStaticLoad, dict(
                 load_parameter=dict(a=0.01, b=0.01, c=0.0)
             )),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau

--- a/gym_electric_motor/envs/gym_pmsm/finite_tc_pmsm_env.py
+++ b/gym_electric_motor/envs/gym_pmsm/finite_tc_pmsm_env.py
@@ -128,7 +128,7 @@ class FiniteTorqueControlPermanentMagnetSynchronousMotorEnv(ElectricMotorEnviron
             converter=initialize(ps.PowerElectronicConverter, converter, ps.FiniteB6BridgeConverter, dict()),
             motor=initialize(ps.ElectricMotor, motor, ps.PermanentMagnetSynchronousMotor, dict()),
             load=initialize(ps.MechanicalLoad, load, ps.ConstantSpeedLoad, dict(omega_fixed=100.0)),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau

--- a/gym_electric_motor/envs/gym_synrm/abccont_cc_synrm_env.py
+++ b/gym_electric_motor/envs/gym_synrm/abccont_cc_synrm_env.py
@@ -133,7 +133,7 @@ class AbcContCurrentControlSynchronousReluctanceMotorEnv(ElectricMotorEnvironmen
             converter=initialize(ps.PowerElectronicConverter, converter, ps.ContB6BridgeConverter, dict()),
             motor=initialize(ps.ElectricMotor, motor, ps.SynchronousReluctanceMotor, dict()),
             load=initialize(ps.MechanicalLoad, load, ps.ConstantSpeedLoad, dict(omega_fixed=100.0)),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau,

--- a/gym_electric_motor/envs/gym_synrm/abccont_sc_synrm_env.py
+++ b/gym_electric_motor/envs/gym_synrm/abccont_sc_synrm_env.py
@@ -130,7 +130,7 @@ class AbcContSpeedControlSynchronousReluctanceMotorEnv(ElectricMotorEnvironment)
             load=initialize(ps.MechanicalLoad, load, ps.PolynomialStaticLoad, dict(
                 load_parameter=dict(a=0.01, b=0.01, c=0.0)
             )),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau,

--- a/gym_electric_motor/envs/gym_synrm/abccont_tc_synrm_env.py
+++ b/gym_electric_motor/envs/gym_synrm/abccont_tc_synrm_env.py
@@ -128,7 +128,7 @@ class AbcContTorqueControlSynchronousReluctanceMotorEnv(ElectricMotorEnvironment
             converter=initialize(ps.PowerElectronicConverter, converter, ps.ContB6BridgeConverter, dict()),
             motor=initialize(ps.ElectricMotor, motor, ps.SynchronousReluctanceMotor, dict()),
             load=initialize(ps.MechanicalLoad, load, ps.ConstantSpeedLoad, dict(omega_fixed=100.0)),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau,

--- a/gym_electric_motor/envs/gym_synrm/dqcont_cc_synrm_env.py
+++ b/gym_electric_motor/envs/gym_synrm/dqcont_cc_synrm_env.py
@@ -133,7 +133,7 @@ class DqContCurrentControlSynchronousReluctanceMotorEnv(ElectricMotorEnvironment
             converter=initialize(ps.PowerElectronicConverter, converter, ps.ContB6BridgeConverter, dict()),
             motor=initialize(ps.ElectricMotor, motor, ps.SynchronousReluctanceMotor, dict()),
             load=initialize(ps.MechanicalLoad, load, ps.ConstantSpeedLoad, dict(omega_fixed=100.0)),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau,

--- a/gym_electric_motor/envs/gym_synrm/dqcont_sc_synrm_env.py
+++ b/gym_electric_motor/envs/gym_synrm/dqcont_sc_synrm_env.py
@@ -130,7 +130,7 @@ class DqContSpeedControlSynchronousReluctanceMotorEnv(ElectricMotorEnvironment):
             load=initialize(ps.MechanicalLoad, load, ps.PolynomialStaticLoad, dict(
                 load_parameter=dict(a=0.01, b=0.01, c=0.0)
             )),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau,

--- a/gym_electric_motor/envs/gym_synrm/dqcont_tc_synrm_env.py
+++ b/gym_electric_motor/envs/gym_synrm/dqcont_tc_synrm_env.py
@@ -128,7 +128,7 @@ class DqContTorqueControlSynchronousReluctanceMotorEnv(ElectricMotorEnvironment)
             converter=initialize(ps.PowerElectronicConverter, converter, ps.ContB6BridgeConverter, dict()),
             motor=initialize(ps.ElectricMotor, motor, ps.SynchronousReluctanceMotor, dict()),
             load=initialize(ps.MechanicalLoad, load, ps.ConstantSpeedLoad, dict(omega_fixed=100.0)),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau,

--- a/gym_electric_motor/envs/gym_synrm/finite_cc_synrm_env.py
+++ b/gym_electric_motor/envs/gym_synrm/finite_cc_synrm_env.py
@@ -133,7 +133,7 @@ class FiniteCurrentControlSynchronousReluctanceMotorEnv(ElectricMotorEnvironment
             converter=initialize(ps.PowerElectronicConverter, converter, ps.FiniteB6BridgeConverter, dict()),
             motor=initialize(ps.ElectricMotor, motor, ps.SynchronousReluctanceMotor, dict()),
             load=initialize(ps.MechanicalLoad, load, ps.ConstantSpeedLoad, dict(omega_fixed=100.0)),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau

--- a/gym_electric_motor/envs/gym_synrm/finite_sc_synrm_env.py
+++ b/gym_electric_motor/envs/gym_synrm/finite_sc_synrm_env.py
@@ -130,7 +130,7 @@ class FiniteSpeedControlSynchronousReluctanceMotorEnv(ElectricMotorEnvironment):
             load=initialize(ps.MechanicalLoad, load, ps.PolynomialStaticLoad, dict(
                 load_parameter=dict(a=0.01, b=0.01, c=0.0)
             )),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau

--- a/gym_electric_motor/envs/gym_synrm/finite_tc_synrm_env.py
+++ b/gym_electric_motor/envs/gym_synrm/finite_tc_synrm_env.py
@@ -128,7 +128,7 @@ class FiniteTorqueControlSynchronousReluctanceMotorEnv(ElectricMotorEnvironment)
             converter=initialize(ps.PowerElectronicConverter, converter, ps.FiniteB6BridgeConverter, dict()),
             motor=initialize(ps.ElectricMotor, motor, ps.SynchronousReluctanceMotor, dict()),
             load=initialize(ps.MechanicalLoad, load, ps.ConstantSpeedLoad, dict(omega_fixed=100.0)),
-            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.EulerSolver, dict()),
+            ode_solver=initialize(ps.OdeSolver, ode_solver, ps.ScipyOdeSolver, dict()),
             noise_generator=initialize(ps.NoiseGenerator, noise_generator, ps.NoiseGenerator, dict()),
             calc_jacobian=calc_jacobian,
             tau=tau

--- a/gym_electric_motor/physical_systems/mechanical_loads/constant_speed_load.py
+++ b/gym_electric_motor/physical_systems/mechanical_loads/constant_speed_load.py
@@ -10,10 +10,12 @@ class ConstantSpeedLoad(MechanicalLoad):
     """
 
     HAS_JACOBIAN = True
-    _default_initializer = {'states': {'omega': 0.0},
-                            'interval': None,
-                            'random_init': None,
-                            'random_params': (None, None)}
+    _default_initializer = {
+        'states': {'omega': 0.0},
+        'interval': None,
+        'random_init': None,
+        'random_params': (None, None)
+    }
 
     @property
     def omega_fixed(self):
@@ -39,4 +41,4 @@ class ConstantSpeedLoad(MechanicalLoad):
 
     def mechanical_jacobian(self, t, mechanical_state, torque):
         # Docstring of superclass
-        return np.array([0]), np.array([0])
+        return np.array([[0]]), np.array([0])

--- a/gym_electric_motor/physical_systems/mechanical_loads/polynomial_static_load.py
+++ b/gym_electric_motor/physical_systems/mechanical_loads/polynomial_static_load.py
@@ -8,10 +8,32 @@ class PolynomialStaticLoad(MechanicalLoad):
     """ Mechanical system that models the Mechanical-ODE based on a static polynomial load torque.
 
     Parameter dictionary entries:
-        | a: Constant Load Torque coefficient (for modeling static friction)
-        | b: Linear Load Torque coefficient (for modeling sliding friction)
-        | c: Quadratic Load Torque coefficient (for modeling air resistances)
-        | j_load: Moment of inertia of the mechanical system.
+        - :math:`a / Nm`: Constant Load Torque coefficient (for modeling static friction)
+        - :math:`b / (Nm s)`: Linear Load Torque coefficient (for modeling sliding friction)
+        - :math:`c / (Nm s^2)`: Quadratic Load Torque coefficient (for modeling air resistances)
+        - :math:`j_load / (kg m^2)` : Moment of inertia of the mechanical system.
+
+    Usage Example:
+        >>> import gym_electric_motor as gem
+        >>> from gym_electric_motor.physical_systems.mechanical_loads import PolynomialStaticLoad
+        >>>
+        >>> # Create a custom PolynomialStaticLoad instance
+        >>> my_poly_static_load = PolynomialStaticLoad(
+        ...     load_parameter=dict(a=1e-3, b=1e-4, c=0.0, j_load=1e-3),
+        ...     limits=dict(omega=150.0), # rad / s
+        ... )
+        >>>
+        >>> env = gem.make(
+        ...     'Cont-SC-ExtExDc-v0',
+        ...     load=my_poly_static_load
+        ... )
+        >>> done = True
+        >>> for _ in range(1000):
+        >>>     if done:
+        >>>         state, reference = env.reset()
+        >>>     env.render()
+        >>>     (state, reference), reward, done, _ = env.step(env.action_space.sample())
+
     """
 
     _load_parameter = dict(a=0.0, b=0.0, c=0., j_load=1e-5)
@@ -40,9 +62,9 @@ class PolynomialStaticLoad(MechanicalLoad):
     def __init__(self, load_parameter=None, limits=None, load_initializer=None):
         """
         Args:
-            load_parameter(dict(float)): Parameter dictionary.
-            limits(dict):
-            load_initializer(dict):
+            load_parameter(dict(float)): Parameter dictionary. Keys: ``'a', 'b', 'c', 'j_load'``
+            limits(dict): dictionary to update the limits of the load-instance. Keys: ``'omega'``
+            load_initializer(dict): Dictionary to parameterize the initializer.
         """
         load_parameter = load_parameter if load_parameter is not None else dict()
         self._load_parameter = update_parameter_dict(self._load_parameter, load_parameter)

--- a/gym_electric_motor/physical_systems/mechanical_loads/polynomial_static_load.py
+++ b/gym_electric_motor/physical_systems/mechanical_loads/polynomial_static_load.py
@@ -52,7 +52,7 @@ class PolynomialStaticLoad(MechanicalLoad):
         self._b = self._load_parameter['b']
         self._c = self._load_parameter['c']
 
-    def _static_load(self, omega, *_):
+    def _static_load(self, omega):
         """Calculation of the load torque for a given speed omega."""
         sign = 1 if omega > 0 else -1 if omega < -0 else 0
         # Limit the constant load term 'a' for velocities around zero for a more stable integration
@@ -64,9 +64,9 @@ class PolynomialStaticLoad(MechanicalLoad):
     def mechanical_ode(self, t, mechanical_state, torque):
         # Docstring of superclass
         omega = mechanical_state[self.OMEGA_IDX]
-        static_load = self._static_load(omega)
-        load = torque - static_load
-        return np.array([load / self._j_total])
+        static_torque = self._static_load(omega)
+        total_torque = torque - static_torque
+        return np.array([total_torque / self._j_total])
 
     def mechanical_jacobian(self, t, mechanical_state, torque):
         # Docstring of superclass

--- a/gym_electric_motor/physical_systems/mechanical_loads/polynomial_static_load.py
+++ b/gym_electric_motor/physical_systems/mechanical_loads/polynomial_static_load.py
@@ -74,5 +74,5 @@ class PolynomialStaticLoad(MechanicalLoad):
         sign = 1 if omega > 0 else -1 if omega < 0 else 0
         # Linear region of the constant load term 'a' ?
         a = 0 if abs(omega) > self._a * self.tau_decay / self._j_total else self._j_total / self.tau_decay
-        return np.array([[(-self._b * sign - 2 * self._c * omega + a) / self._j_total]]), \
+        return np.array([[(-self._b - 2 * sign * self._c * omega - a) / self._j_total]]), \
             np.array([1 / self._j_total])

--- a/gym_electric_motor/physical_systems/mechanical_loads/polynomial_static_load.py
+++ b/gym_electric_motor/physical_systems/mechanical_loads/polynomial_static_load.py
@@ -15,10 +15,16 @@ class PolynomialStaticLoad(MechanicalLoad):
     """
 
     _load_parameter = dict(a=0.0, b=0.0, c=0., j_load=1e-5)
-    _default_initializer = {'states': {'omega': 0.0},
-                            'interval': None,
-                            'random_init': None,
-                            'random_params': (None, None)}
+    _default_initializer = {
+        'states': {'omega': 0.0},
+        'interval': None,
+        'random_init': None,
+        'random_params': (None, None)
+    }
+
+    #: Time constant to smoothen the static load functions constant term "a" around 0 velocity
+    # Steps of a lead to unstable behavior of the ode-solver.
+    tau_decay = 1e-3
 
     #: Parameter indicating if the class is implementing the optional jacobian function
     HAS_JACOBIAN = True
@@ -47,18 +53,26 @@ class PolynomialStaticLoad(MechanicalLoad):
         self._c = self._load_parameter['c']
 
     def _static_load(self, omega, *_):
-        """
-        Calculation of the load torque for a given speed omega.
-        """
-        sign = 1 if omega > 0 else -1 if omega < 0 else 0
-        return sign * (self._c * omega**2 + self._b * abs(omega) + self._a)
+        """Calculation of the load torque for a given speed omega."""
+        sign = 1 if omega > 0 else -1 if omega < -0 else 0
+        # Limit the constant load term 'a' for velocities around zero for a more stable integration
+        a = sign * self._a \
+            if abs(omega) > self._a / self._j_total * self.tau_decay \
+            else self._j_total / self.tau_decay * omega
+        return sign * self._c * omega**2 + self._b * omega + a
 
     def mechanical_ode(self, t, mechanical_state, torque):
         # Docstring of superclass
-        return np.array([(torque - self._static_load(mechanical_state[self.OMEGA_IDX])) / self._j_total])
+        omega = mechanical_state[self.OMEGA_IDX]
+        static_load = self._static_load(omega)
+        load = torque - static_load
+        return np.array([load / self._j_total])
 
     def mechanical_jacobian(self, t, mechanical_state, torque):
         # Docstring of superclass
-        sign = 1 if mechanical_state[self.OMEGA_IDX] > 0 else -1 if mechanical_state[self.OMEGA_IDX] < 0 else 0
-        return np.array([[(-self._b * sign - 2 * self._c * mechanical_state[self.OMEGA_IDX])/self._j_total]]), \
-            np.array([1/self._j_total])
+        omega = mechanical_state[self.OMEGA_IDX]
+        sign = 1 if omega > 0 else -1 if omega < 0 else 0
+        # Linear region of the constant load term 'a' ?
+        a = 0 if abs(omega) > self._a * self.tau_decay / self._j_total else self._j_total / self.tau_decay
+        return np.array([[(-self._b * sign - 2 * self._c * omega + a) / self._j_total]]), \
+            np.array([1 / self._j_total])


### PR DESCRIPTION
The constant static load term of the Polynomial Static Load has been adapted to have a linear behavior in the region near zero angular velocity to stabilize the ODE-solver. 

A linear interpolation between the positive and the negative constant torque seems to be a very stable solution. It is even more stable than the already discussed solution: To use a 0 torque between the positive and negative torque level.

The scipy.ode integrator solves the ODE now very stable, so it has been switched to the default solver.

Furthermore, a little bug has been fixed in the jacobian of the Constant Speed Load