### PR TITLE
Uniform initialization for WienerProcessReferenceGenerator

### DIFF
--- a/gym_electric_motor/reference_generators/wiener_process_reference_generator.py
+++ b/gym_electric_motor/reference_generators/wiener_process_reference_generator.py
@@ -44,5 +44,5 @@ class WienerProcessReferenceGenerator(SubepisodedReferenceGenerator):
         if initial_reference is None:
             initial_reference = np.zeros_like(self._referenced_states, dtype=float)
             initial_reference[self._referenced_states] =\
-                np.random.uniform(self._initial_range[0], self._initial_range[1], 1)
+                self.random_generator.uniform(self._initial_range[0], self._initial_range[1], 1)
         return super().reset(initial_state, initial_reference)

--- a/tests/test_physical_systems/test_mechanical_loads.py
+++ b/tests/test_physical_systems/test_mechanical_loads.py
@@ -319,8 +319,8 @@ class TestPolyStaticLoad(TestMechanicalLoad):
     key = 'PolyStaticLoad'
 
     @pytest.mark.parametrize('omega, load_parameter, expected', [
-        (-0.5, dict(a=12, b=1, c=0, j_load=1), (1, 1)),
-        (0, dict(j_load=0.5), (0, 2)),
+        (-0.5, dict(a=12, b=1, c=0, j_load=1), (np.array([[-1.]]), np.array([[1.]]))),
+        (0, dict(j_load=0.5), (np.array([[-1000.]]), np.array([[2.]]))),
         (2, dict(a=20, b=0, c=2, j_load=0.25), (-32, 4)),
         (2, dict(a=20, b=0.125, c=2, j_load=0.25), (-32.5, 4))
     ]


### PR DESCRIPTION
A uniform initialization for the WienerProcessReferenceGenerator has been added. 

This is a first step towards initializers for all Reference Generators as demanded within issue #146

However, the Wiener Generator is the default generator in the environments. Therefore, I think it is useful to forward these changes early to the nightly / master.

The test changes are piggybacked and do not belong directly to this PR. However, I noticed that the tests in the nightly fail and fixed them. It seems that the tests are no requirement for the merge into the nightly anymore. I will open a new issue for that.