### PR TITLE
Fixed issue 116. Warning on floating type precision

### DIFF
--- a/gym_electric_motor/core.py
+++ b/gym_electric_motor/core.py
@@ -214,7 +214,7 @@ class ElectricMotorEnvironment(gym.core.Env):
         self.state_filter = [self._physical_system.state_names.index(s) for s in state_filter]
         states_low = self._physical_system.state_space.low[self.state_filter]
         states_high = self._physical_system.state_space.high[self.state_filter]
-        state_space = Box(states_low, states_high)
+        state_space = Box(states_low, states_high, dtype=np.float64)
         self.observation_space = gym.spaces.Tuple((
             state_space,
             self._reference_generator.reference_space

--- a/gym_electric_motor/physical_systems/converters.py
+++ b/gym_electric_motor/physical_systems/converters.py
@@ -113,9 +113,9 @@ class NoConverter(PowerElectronicConverter):
     """Dummy Converter class used to directly transfer the supply voltage to the motor"""
     # Dummy default values for voltages and currents.
     # No real use other than to fit the current physical system architecture
-    voltages = Box(0, 1, shape=(3,))
-    currents = Box(0, 1, shape=(3,))
-    action_space = Box(low=np.array([]), high=np.array([]))
+    voltages = Box(0, 1, shape=(3,), dtype=np.float64)
+    currents = Box(0, 1, shape=(3,), dtype=np.float64)
+    action_space = Box(low=np.array([]), high=np.array([]), dtype=np.float64)
 
     def i_sup(self, i_out):
         return i_out[0]
@@ -219,8 +219,8 @@ class FiniteOneQuadrantConverter(FiniteConverter):
         | currents: Box(0, 1, shape=(1,))
     """
 
-    voltages = Box(0, 1, shape=(1,))
-    currents = Box(0, 1, shape=(1,))
+    voltages = Box(0, 1, shape=(1,), dtype=np.float64)
+    currents = Box(0, 1, shape=(1,), dtype=np.float64)
     action_space = Discrete(2)
 
     def convert(self, i_out, t):
@@ -250,8 +250,8 @@ class FiniteTwoQuadrantConverter(FiniteConverter):
         | currents: Box(-1, 1, shape=(1,))
     """
 
-    voltages = Box(0, 1, shape=(1,))
-    currents = Box(-1, 1, shape=(1,))
+    voltages = Box(0, 1, shape=(1,), dtype=np.float64)
+    currents = Box(-1, 1, shape=(1,), dtype=np.float64)
     action_space = Discrete(3)
 
     def convert(self, i_out, t):
@@ -317,8 +317,8 @@ class FiniteFourQuadrantConverter(FiniteConverter):
         | Box(-1, 1, shape=(1,))
         | Box(-1, 1, shape=(1,))
     """
-    voltages = Box(-1, 1, shape=(1,))
-    currents = Box(-1, 1, shape=(1,))
+    voltages = Box(-1, 1, shape=(1,), dtype=np.float64)
+    currents = Box(-1, 1, shape=(1,), dtype=np.float64)
     action_space = Discrete(4)
 
     def __init__(self, **kwargs):
@@ -367,9 +367,9 @@ class ContOneQuadrantConverter(ContDynamicallyAveragedConverter):
         | voltages: Box(0, 1, shape=(1,))
         | currents: Box(0, 1, shape=(1,))
     """
-    voltages = Box(0, 1, shape=(1,))
-    currents = Box(0, 1, shape=(1,))
-    action_space = Box(0, 1, shape=(1,))
+    voltages = Box(0, 1, shape=(1,), dtype=np.float64)
+    currents = Box(0, 1, shape=(1,), dtype=np.float64)
+    action_space = Box(0, 1, shape=(1,), dtype=np.float64)
 
     def _convert(self, i_in, *_):
         # Docstring in base class
@@ -400,9 +400,9 @@ class ContTwoQuadrantConverter(ContDynamicallyAveragedConverter):
         | voltages: Box(0, 1, shape=(1,))
         | currents: Box(-1, 1, shape=(1,))
     """
-    voltages = Box(0, 1, shape=(1,))
-    currents = Box(-1, 1, shape=(1,))
-    action_space = Box(0, 1, shape=(1,))
+    voltages = Box(0, 1, shape=(1,), dtype=np.float64)
+    currents = Box(-1, 1, shape=(1,), dtype=np.float64)
+    action_space = Box(0, 1, shape=(1,), dtype=np.float64)
 
 
     def _convert(self, *_):
@@ -438,9 +438,9 @@ class ContFourQuadrantConverter(ContDynamicallyAveragedConverter):
         | voltages: Box(-1, 1, shape=(1,))
         | currents: Box(-1, 1, shape=(1,))
     """
-    voltages = Box(-1, 1, shape=(1,))
-    currents = Box(-1, 1, shape=(1,))
-    action_space = Box(-1, 1, shape=(1,))
+    voltages = Box(-1, 1, shape=(1,), dtype=np.float64)
+    currents = Box(-1, 1, shape=(1,), dtype=np.float64)
+    action_space = Box(-1, 1, shape=(1,), dtype=np.float64)
 
     def __init__(self, **kwargs):
         # Docstring in base class
@@ -540,8 +540,8 @@ class FiniteMultiConverter(FiniteConverter):
 
         # put limits into gym_space format
         self.action_space = MultiDiscrete(self.action_space)
-        self.currents = Box(currents_low, currents_high)
-        self.voltages = Box(voltages_low, voltages_high)
+        self.currents = Box(currents_low, currents_high, dtype=np.float64)
+        self.voltages = Box(voltages_low, voltages_high, dtype=np.float64)
 
     def convert(self, i_out, t):
         # Docstring in base class
@@ -644,9 +644,9 @@ class ContMultiConverter(ContDynamicallyAveragedConverter):
         voltages_high = np.concatenate(voltages_high)
 
         # put limits into gym_space format
-        self.action_space = Box(action_space_low, action_space_high)
-        self.currents = Box(currents_low, currents_high)
-        self.voltages = Box(voltages_low, voltages_high)
+        self.action_space = Box(action_space_low, action_space_high, dtype=np.float64)
+        self.currents = Box(currents_low, currents_high, dtype=np.float64)
+        self.voltages = Box(voltages_low, voltages_high, dtype=np.float64)
 
     def set_action(self, action, t):
         # Docstring in base class
@@ -732,9 +732,9 @@ class FiniteB6BridgeConverter(FiniteConverter):
 
     action_space = Discrete(8)
     # Only positive voltages can be applied
-    voltages = Box(-1, 1, shape=(3,))
+    voltages = Box(-1, 1, shape=(3,), dtype=np.float64)
     # positive and negative currents are possible
-    currents = Box(-1, 1, shape=(3,))
+    currents = Box(-1, 1, shape=(3,), dtype=np.float64)
     _reset_action = 0
     _subactions = [
         [2, 2, 2],
@@ -810,11 +810,11 @@ class ContB6BridgeConverter(ContDynamicallyAveragedConverter):
         Box(-0.5, 0.5, shape=(3,))
     """
 
-    action_space = Box(-1, 1, shape=(3,))
+    action_space = Box(-1, 1, shape=(3,), dtype=np.float64)
     # Only positive voltages can be applied
-    voltages = Box(-1, 1, shape=(3,))
+    voltages = Box(-1, 1, shape=(3,), dtype=np.float64)
     # Positive and negative currents are possible
-    currents = Box(-1, 1, shape=(3,))
+    currents = Box(-1, 1, shape=(3,), dtype=np.float64)
 
     _reset_action = [0, 0, 0]
 

--- a/gym_electric_motor/physical_systems/physical_systems.py
+++ b/gym_electric_motor/physical_systems/physical_systems.py
@@ -317,7 +317,7 @@ class DcMotorSystem(SCMLSystem):
             low['u_sup'] = 0
         low = set_state_array(low, state_names)
         high = set_state_array(high, state_names)
-        return Box(low, high)
+        return Box(low, high, dtype=np.float64)
 
 
 class ThreePhaseMotorSystem(SCMLSystem):
@@ -432,14 +432,14 @@ class SynchronousMotorSystem(ThreePhaseMotorSystem):
         if control_space == 'dq':
             assert type(self._converter.action_space) == Box, \
                 'dq-control space is only available for Continuous Controlled Converters'
-            self._action_space = Box(-1, 1, shape=(2,))
+            self._action_space = Box(-1, 1, shape=(2,), dtype=np.float64)
 
     def _build_state_space(self, state_names):
         # Docstring of superclass
         low = -1 * np.ones_like(state_names, dtype=float)
         low[self.U_SUP_IDX] = 0.0
         high = np.ones_like(state_names, dtype=float)
-        return Box(low, high)
+        return Box(low, high, dtype=np.float64)
 
     def _build_state_names(self):
         # Docstring of superclass
@@ -571,14 +571,14 @@ class SquirrelCageInductionMotorSystem(ThreePhaseMotorSystem):
         super().__init__(ode_solver=ode_solver, **kwargs)
         self.control_space = control_space
         if control_space == 'dq':
-            self._action_space = Box(-1, 1, shape=(2,))
+            self._action_space = Box(-1, 1, shape=(2,), dtype=np.float64)
 
     def _build_state_space(self, state_names):
         # Docstring of superclass
         low = -1 * np.ones_like(state_names, dtype=float)
         low[self.U_SUP_IDX] = 0.0
         high = np.ones_like(state_names, dtype=float)
-        return Box(low, high)
+        return Box(low, high, dtype=np.float64)
 
     def _build_state_names(self):
         # Docstring of superclass
@@ -721,7 +721,7 @@ class DoublyFedInductionMotorSystem(ThreePhaseMotorSystem):
         super().__init__(ode_solver=ode_solver, **kwargs)
         self.control_space = control_space
         if control_space == 'dq':
-            self._action_space = Box(-1, 1, shape=(4,))
+            self._action_space = Box(-1, 1, shape=(4,), dtype=np.float64)
 
         self.stator_voltage_space_idx = 0
         self.stator_voltage_low_idx = 0
@@ -750,7 +750,7 @@ class DoublyFedInductionMotorSystem(ThreePhaseMotorSystem):
         low = -1 * np.ones_like(state_names, dtype=float)
         low[self.U_SUP_IDX] = 0.0
         high = np.ones_like(state_names, dtype=float)
-        return Box(low, high)
+        return Box(low, high, dtype=np.float64)
 
     def _build_state_names(self):
         # Docstring of superclass

--- a/gym_electric_motor/reference_generators/const_reference_generator.py
+++ b/gym_electric_motor/reference_generators/const_reference_generator.py
@@ -19,7 +19,7 @@ class ConstReferenceGenerator(ReferenceGenerator):
         super().__init__(**kwargs)
         self._reference_value = reference_value
         self._reference_state = reference_state.lower()
-        self.reference_space = Box(np.array([reference_value]), np.array([reference_value]))
+        self.reference_space = Box(np.array([reference_value]), np.array([reference_value]), dtype=np.float64)
         self._reference_names = self._reference_state
 
     def set_modules(self, physical_system):

--- a/gym_electric_motor/reference_generators/multiple_reference_generator.py
+++ b/gym_electric_motor/reference_generators/multiple_reference_generator.py
@@ -21,7 +21,7 @@ class MultipleReferenceGenerator(ReferenceGenerator, gem.RandomComponent):
         """
         ReferenceGenerator.__init__(self, **kwargs)
         gem.RandomComponent.__init__(self)
-        self.reference_space = Box(-1, 1, shape=(1,))
+        self.reference_space = Box(-1, 1, shape=(1,), dtype=np.float64)
         if type(sub_args) is dict:
             sub_arguments = [sub_args] * len(sub_generators)
         elif hasattr(sub_args, '__iter__'):
@@ -50,7 +50,7 @@ class MultipleReferenceGenerator(ReferenceGenerator, gem.RandomComponent):
 
         ref_space_low = np.concatenate([sub_generator.reference_space.low for sub_generator in self._sub_generators])
         ref_space_high = np.concatenate([sub_generator.reference_space.high for sub_generator in self._sub_generators])
-        self.reference_space = Box(ref_space_low, ref_space_high)
+        self.reference_space = Box(ref_space_low, ref_space_high, dtype=np.float64)
         self._referenced_states = np.sum(
             [sub_generator.referenced_states for sub_generator in self._sub_generators], dtype=bool, axis=0
         )

--- a/gym_electric_motor/reference_generators/subepisoded_reference_generator.py
+++ b/gym_electric_motor/reference_generators/subepisoded_reference_generator.py
@@ -26,7 +26,7 @@ class SubepisodedReferenceGenerator(ReferenceGenerator, RandomComponent):
         """
         ReferenceGenerator.__init__(self, **kwargs)
         RandomComponent.__init__(self)
-        self.reference_space = Box(-1, 1, shape=(1,))
+        self.reference_space = Box(-1, 1, shape=(1,), dtype=np.float64)
         self._reference = None
         self._limit_margin = limit_margin
         self._reference_value = 0.0
@@ -57,7 +57,7 @@ class SubepisodedReferenceGenerator(ReferenceGenerator, RandomComponent):
             self._limit_margin = lower_margin[0], upper_margin[0]
         else:
             raise Exception('Unknown type for the limit margin.')
-        self.reference_space = Box(lower_margin[0], upper_margin[0], shape=(1,))
+        self.reference_space = Box(lower_margin[0], upper_margin[0], shape=(1,), dtype=np.float64)
 
     def reset(self, initial_state=None, initial_reference=None):
         """

--- a/gym_electric_motor/reference_generators/switched_reference_generator.py
+++ b/gym_electric_motor/reference_generators/switched_reference_generator.py
@@ -20,7 +20,7 @@ class SwitchedReferenceGenerator(ReferenceGenerator, RandomComponent):
         """
         ReferenceGenerator.__init__(self)
         RandomComponent.__init__(self)
-        self.reference_space = Box(-1, 1, shape=(1,))
+        self.reference_space = Box(-1, 1, shape=(1,), dtype=np.float64)
         self._reference = None
         self._k = 0
 

--- a/gym_electric_motor/reference_generators/zero_reference_generator.py
+++ b/gym_electric_motor/reference_generators/zero_reference_generator.py
@@ -9,7 +9,7 @@ class ZeroReferenceGenerator(ReferenceGenerator):
 
     def __init__(self):
         super().__init__()
-        self.reference_space = Box(0, 0, (0,))
+        self.reference_space = Box(0, 0, (0,), dtype=np.float64)
         self._reference_names = []
 
     def set_modules(self, physical_system):

--- a/tests/conf.py
+++ b/tests/conf.py
@@ -15,7 +15,7 @@ series_motor_parameter = {'motor_parameter': {'r_a': 3.78, 'r_e': 35, 'l_a': 6.3
                           'nominal_values': {'omega': 370, 'torque': 40, 'i': 50, 'u': 430},
                           'reward_weights': {'omega': 1, 'torque': 0, 'i': 0, 'u': 0, 'u_sup': 0}}
 series_state_positions = {'omega': 0, 'torque': 1, 'i': 2, 'u': 3, 'u_sup': 4}
-series_state_space = Box(low=-1, high=1, shape=(5,))
+series_state_space = Box(low=-1, high=1, shape=(5,), dtype=np.float64)
 series_initializer = {'states': {'i': 0.0},
                       'interval': None,
                       'random_init': None,
@@ -27,7 +27,7 @@ shunt_motor_parameter = {'motor_parameter': {'r_a': 3.78, 'r_e': 35, 'l_a': 6.3e
                          'nominal_values': {'omega': 368, 'torque': 40, 'i_a': 50, 'i_e': 5, 'u': 430},
                          'reward_weights': {'omega': 1, 'torque': 0, 'i_a': 0, 'i_e': 0, 'u': 0, 'u_sup': 0}}
 shunt_state_positions = {'omega': 0, 'torque': 1, 'i_a': 2, 'i_e': 3, 'u': 4, 'u_sup': 5}
-shunt_state_space = Box(low=-1, high=1, shape=(6,))
+shunt_state_space = Box(low=-1, high=1, shape=(6,), dtype=np.float64)
 shunt_initializer = {'states': {'i_a': 0.0, 'i_e': 0.0},
                      'interval': None,
                      'random_init': None,
@@ -42,7 +42,7 @@ extex_motor_parameter = {'motor_parameter': {'r_a': 3.78, 'r_e': 35, 'l_a': 6.3e
                          'reward_weights': {'omega': 1, 'torque': 0, 'i_a': 0, 'i_e': 0, 'u_a': 0, 'u_e': 0,
                                             'u_sup': 0}}
 extex_state_positions = {'omega': 0, 'torque': 1, 'i_a': 2, 'i_e': 3, 'u_a': 4, 'u_e': 5, 'u_sup': 6}
-extex_state_space = Box(low=-1, high=1, shape=(7,))
+extex_state_space = Box(low=-1, high=1, shape=(7,), dtype=np.float64)
 extex_initializer = {'states': {'i_a': 0.0, 'i_e': 0.0},
                         'interval': None,
                         'random_init': None,
@@ -55,7 +55,7 @@ permex_motor_parameter = {'motor_parameter': {'r_a': 3.78, 'l_a': 6.3e-3, 'psi_e
                           'nominal_values': {'omega': 368, 'torque': 40, 'i': 50, 'u': 460},
                           'reward_weights': {'omega': 1, 'torque': 0, 'i': 0, 'u': 0, 'u_sup': 0}}
 permex_state_positions = {'omega': 0, 'torque': 1, 'i': 2, 'u': 3, 'u_sup': 4}
-permex_state_space = Box(low=-1, high=1, shape=(5,))
+permex_state_space = Box(low=-1, high=1, shape=(5,), dtype=np.float64)
 permex_initializer = {'states': {'i': 0.0},
                       'interval': None,
                       'random_init': None,
@@ -70,7 +70,7 @@ pmsm_motor_parameter = {'motor_parameter': {'p': 3, 'l_d': 84e-3, 'l_q': 125e-3,
 pmsm_state_positions = {'omega': 0, 'torque': 1, 'i_a': 2, 'i_b': 3, 'i_c': 4,
                         'i_sq': 5, 'i_sd': 6, 'u_a': 7, 'u_b': 8, 'u_c': 9,
                         'u_sq': 10, 'u_sd': 11, 'epsilon': 12, 'u_sup': 13}
-pmsm_state_space = Box(low=-1, high=1, shape=(14,))
+pmsm_state_space = Box(low=-1, high=1, shape=(14,), dtype=np.float64)
 pmsm_initializer = {'states': {'i_sq': 0.0, 'i_sd': 0.0, 'epsilon': 0.0},
                     'interval': None,
                     'random_init': None,
@@ -84,7 +84,7 @@ synrm_motor_parameter = {
 synrm_state_positions = {'omega': 0, 'torque': 1, 'i_a': 2, 'i_b': 3, 'i_c': 4,
                          'i_sq': 5, 'i_sd': 6, 'u_a': 7, 'u_b': 8, 'u_c': 9,
                          'u_sq': 10, 'u_sd': 11, 'epsilon': 12, 'u_sup': 13}
-synrm_state_space = Box(low=-1, high=1, shape=(14,))
+synrm_state_space = Box(low=-1, high=1, shape=(14,), dtype=np.float64)
 synrm_initializer = {'states': {'i_sq': 0.0, 'i_sd': 0.0, 'epsilon': 0.0},
                      'interval': None,
                      'random_init': None,
@@ -98,7 +98,7 @@ sci_motor_parameter = {
 sci_state_positions = {'omega': 0, 'torque': 1, 'i_sa': 2, 'i_sb': 3, 'i_sc': 4,
                         'i_sq': 5, 'i_sd': 6, 'u_sa': 7, 'u_sb': 8, 'u_sc': 9,
                         'u_sq': 10, 'u_sd': 11, 'epsilon': 12, 'u_sup': 13}
-sci_state_space = Box(low=-1, high=1, shape=(14,))
+sci_state_space = Box(low=-1, high=1, shape=(14,), dtype=np.float64)
 sci_initializer = {'states': {'i_salpha': 0.0, 'i_sbeta': 0.0,
                                'psi_ralpha': 0.0, 'psi_rbeta': 0.0,
                                'epsilon': 0.0},
@@ -111,7 +111,7 @@ dfim_state_positions = {'omega': 0, 'torque': 1, 'i_sa': 2, 'i_sb': 3, 'i_sc': 4
                         'i_rq': 10, 'i_rd': 11, 'u_sa': 12, 'u_sb': 13, 'u_sc': 14,
                         'u_sq': 15, 'u_sd': 16, 'u_ra': 17, 'u_rb': 18, 'u_rc': 19,
                         'u_rq': 20, 'u_rd': 21, 'epsilon': 22, 'u_sup': 23}
-dfim_state_space = Box(low=-1, high=1, shape=(24,))
+dfim_state_space = Box(low=-1, high=1, shape=(24,), dtype=np.float64)
 dfim_initializer = {'states': {'i_salpha': 0.0, 'i_sbeta': 0.0,
                                 'psi_ralpha': 0.0, 'psi_rbeta': 0.0,
                                 'epsilon': 0.0},

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -150,9 +150,9 @@ def mock_instantiate(superclass, key, **kwargs):
 class DummyReferenceGenerator(ReferenceGenerator):
     _reset_counter = 0
 
-    def __init__(self, reference_observation=np.array([1]), reference_state='dummy_state_0', **kwargs):
+    def __init__(self, reference_observation=np.array([1.]), reference_state='dummy_state_0', **kwargs):
         super().__init__()
-        self.reference_space = Box(0, 1, shape=(1,))
+        self.reference_space = Box(0., 1., shape=(1,), dtype=np.float64)
         self.kwargs = kwargs
         self._reference_names = [reference_state]
         self.closed = False
@@ -246,7 +246,7 @@ class DummyPhysicalSystem(PhysicalSystem):
 
     def __init__(self, state_length=1, state_names='dummy_state', **kwargs):
         super().__init__(
-            Box(-1, 1, shape=(1,)), Box(-1, 1, shape=(state_length,)),
+            Box(-1, 1, shape=(1,), dtype=np.float64), Box(-1, 1, shape=(state_length,), dtype=np.float64),
             [f'{state_names}_{i}' for i in range(state_length)], 1
         )
         self._limits = np.array([10 * (i + 1) for i in range(state_length)])
@@ -257,7 +257,7 @@ class DummyPhysicalSystem(PhysicalSystem):
         self.kwargs = kwargs
 
     def reset(self, initial_state=None):
-        self.state = np.array([0] * len(self._state_names))
+        self.state = np.array([0.] * len(self._state_names))
         return self.state
 
     def simulate(self, action):
@@ -324,8 +324,8 @@ class DummyVoltageSupply(VoltageSupply):
 
 class DummyConverter(PowerElectronicConverter):
 
-    voltages = Box(0, 1, shape=(1,))
-    currents = Box(-1, 1, shape=(1,))
+    voltages = Box(0, 1, shape=(1,), dtype=np.float64)
+    currents = Box(-1, 1, shape=(1,), dtype=np.float64)
     action_space = Discrete(4)
 
     def __init__(self, tau=2E-4, dead_time=False, interlocking_time=0, action_space=None, voltages=None, currents=None, **kwargs):


### PR DESCRIPTION
By adding the explicit datatype `np.float64` to each `gym.spaces.Box` instantiation, the warning that has showed up at every environment creation (c.f. #116) is avoided.

I also investigated, if a change to `np.float32` could speed up the calculations. However, it seems to have no effect for typical array length (~10) in GEM. 

(see image)
In the upper case, a calculation with arrays of dtype np.float64 is executed and in the lower case with np.float32. 

![grafik](https://user-images.githubusercontent.com/50244395/138514248-1947e3d1-affb-4001-b6de-02d15a2ce85f.png)
