### PR TITLE
Fix to Python 3.8 being deprecated for Sphinx-Build

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -31,15 +31,12 @@ jobs:
     - name: Test with pytest
       env:
         PY_VER: ${{ matrix.python-version }}
-      run: |
-        if [[ "$PY_VER" = "3.7" ]]; then pytest --cov=gym_electric_motor tests/; else pytest; fi
-        if [[ "$PY_VER" = "3.7" ]]; then bash <(curl -s https://codecov.io/bash); fi # code coverage report upload
   build-doc:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - name: Build Sphinx documentation
-      uses: ammaraskar/sphinx-action@master
+      uses: josh146/sphinx-action@master
       with:
         pre-build-command: "python -m pip install sphinx m2r2 sphinx_rtd_theme==1.3.0 && python -m pip install -r requirements.txt & python -m pip install ."
         docs-folder: "docs/"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -31,6 +31,8 @@ jobs:
     - name: Test with pytest
       env:
         PY_VER: ${{ matrix.python-version }}
+      run: |
+        pytest; fi
   build-doc:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Build Sphinx documentation
       uses: josh146/sphinx-action@master
       with:
-        pre-build-command: "python -m pip install sphinx m2r2 sphinx_rtd_theme==1.3.0 && python -m pip install -r requirements.txt & python -m pip install ."
+        pre-build-command: "python -m pip install sphinx m2r2 sphinx_rtd_theme==1.3.0 && pip install --upgrade jinja2 && python -m pip install -r requirements.txt & python -m pip install ."
         docs-folder: "docs/"
     # Publish built docs to gh-pages branch.
     # ===============================

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Build Sphinx documentation
       uses: nicholasphair/sphinx-action@7.0.0
       with:
-        pre-build-command: "python -m pip install sphinx m2r2 sphinx_rtd_theme==1.3.0 && python -m pip install -r requirements.txt & python -m pip install ."
+        pre-build-command: "python -m pip install sphinx m2r2 sphinx_rtd_theme==1.3.0 && python -m pip install -r requirements.txt && python -m pip install ."
         docs-folder: "docs/"
     # Publish built docs to gh-pages branch.
     # ===============================

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Build Sphinx documentation
       uses: josh146/sphinx-action@master
       with:
-        pre-build-command: "python -m pip install sphinx m2r2 sphinx_rtd_theme==1.3.0 && pip install --upgrade jinja2 && python -m pip install -r requirements.txt & python -m pip install ."
+        pre-build-command: "python -m pip install --upgrade sphinx m2r2 sphinx_rtd_theme &&  python -m pip install -r requirements.txt & python -m pip install ."
         docs-folder: "docs/"
     # Publish built docs to gh-pages branch.
     # ===============================

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -38,9 +38,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Build Sphinx documentation
-      uses: josh146/sphinx-action@master
+      uses: Queens-Physics/sphinx-action@master
       with:
-        pre-build-command: "python -m pip install --upgrade sphinx m2r2 sphinx_rtd_theme &&  python -m pip install -r requirements.txt & python -m pip install ."
+        pre-build-command: "python -m pip install sphinx m2r2 sphinx_rtd_theme==1.3.0 &&  python -m pip install -r requirements.txt & python -m pip install ."
         docs-folder: "docs/"
     # Publish built docs to gh-pages branch.
     # ===============================

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -38,9 +38,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Build Sphinx documentation
-      uses: Queens-Physics/sphinx-action@master
+      uses: nicholasphair/sphinx-action@7.0.0
       with:
-        pre-build-command: "python -m pip install sphinx m2r2 sphinx_rtd_theme==1.3.0 &&  python -m pip install -r requirements.txt & python -m pip install ."
+        pre-build-command: "python -m pip install sphinx m2r2 sphinx_rtd_theme==1.3.0 && python -m pip install -r requirements.txt & python -m pip install ."
         docs-folder: "docs/"
     # Publish built docs to gh-pages branch.
     # ===============================

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -32,7 +32,7 @@ jobs:
       env:
         PY_VER: ${{ matrix.python-version }}
       run: |
-        pytest; fi
+        pytest
   build-doc:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
As the old GitHub action relies on Python 3.8 which is not supported by GEM anymore, we will have to explore (temporary) solutions for this. 